### PR TITLE
build: update eslint to v9.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @anytinz/eslint-config
 
+## 2.1.0
+
+### Minor Changes
+
+- build: update eslint to v9.12.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anytinz/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/anytinz/eslint-config.git"
@@ -64,7 +64,7 @@
     "typescript": "5.6.2"
   },
   "peerDependencies": {
-    "eslint": "9.11.1"
+    "eslint": "9.12.0"
   },
   "packageManager": "pnpm@9.12.0",
   "engines": {


### PR DESCRIPTION
Update the peer dependency version of eslint to 9.12.0 to ensure compatibility with the latest features and fixes.