### PR TITLE
feat(configs/tailwindcss): disable no-arbitrary-value rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @anytinz/eslint-config
 
+## 2.5.0
+
+### Minor Changes
+
+- disable tailwindcss/no-arbitrary-value rule
+
 ## 2.4.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anytinz/eslint-config",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/anytinz/eslint-config.git"

--- a/src/configs/tailwindcss.ts
+++ b/src/configs/tailwindcss.ts
@@ -9,7 +9,7 @@ export const resolveTailwindcssRules = (): Required<TailwindcssRules> => ({
   'tailwindcss/enforces-negative-arbitrary-values': 'error',
   'tailwindcss/enforces-shorthand': 'error',
   'tailwindcss/migration-from-tailwind-2': 'error',
-  'tailwindcss/no-arbitrary-value': 'error',
+  'tailwindcss/no-arbitrary-value': 'off',
   'tailwindcss/no-contradicting-classname': 'error',
   'tailwindcss/no-custom-classname': 'error',
   'tailwindcss/no-unnecessary-arbitrary-value': 'error',


### PR DESCRIPTION
Disable the `tailwindcss/no-arbitrary-value` rule to allow more flexibility in using arbitrary values.